### PR TITLE
Remove MATRIX USER_ID variable

### DIFF
--- a/.github/workflows/publish_content.yml
+++ b/.github/workflows/publish_content.yml
@@ -49,7 +49,6 @@ jobs:
           BLUESKY_PASSWORD: ${{ secrets.BLUESKY_PASSWORD }}
           MATRIX_ACCESS_TOKEN: ${{ secrets.MATRIX_ACCESS_TOKEN }}
           MATRIX_ROOM_ID: ${{ secrets.MATRIX_ROOM_ID }}
-          MATRIX_USER_ID: ${{ secrets.MATRIX_USER_ID }}
           SLACK_ACCESS_TOKEN: ${{ secrets.SLACK_ACCESS_TOKEN }}
           SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
           CHANGED_FILES: ${{ steps.get_changed_files.outputs.all_changed_files }}

--- a/lib/plugins/matrix.py
+++ b/lib/plugins/matrix.py
@@ -14,7 +14,6 @@ class matrix_client:
         self.base_url = kwargs.get("base_url", "https://matrix.org")
         self.client = AsyncClient(self.base_url)
         self.client.access_token = kwargs.get("access_token")
-        self.client.user_id = kwargs.get("user_id")
         self.client.device_id = kwargs.get("device_id")
         self.room_id = kwargs.get("room_id")
 

--- a/plugins.yml
+++ b/plugins.yml
@@ -23,7 +23,6 @@ plugins:
       base_url: "https://matrix.org"
       access_token: $MATRIX_ACCESS_TOKEN
       room_id: $MATRIX_ROOM_ID
-      user_id: $MATRIX_USER_ID
 
   - name: slack
     class: slack.slack_client


### PR DESCRIPTION
The user_id variable is not needed to initiate the matrix client.