### PR TITLE
Edit regex format for fixing Blusky mentions

### DIFF
--- a/github_run.py
+++ b/github_run.py
@@ -25,7 +25,7 @@ class github_run:
         # to avoid destroying links.
         # by accident.
         comment_text = re.sub(
-            r"([^a-zA-Z0-9_/])((?:[@][\w-]+)(?:[@][\w.-]+)?)",
+            r"([^a-zA-Z0-9_/])((?:[@][\w-]+)(?:[@.][\w.-]+)?)",
             lambda m: f"{m.group(1)}`{m.group(2)}`",
             comment_text
         )


### PR DESCRIPTION
Previously, the regular expression was incorrectly capturing mentions of Bluesky as `@galaxyproject`.bsky.social.
This PR corrects this issue by adjusting the regular expression to capture Bluesky and Mastodon mentions accurately.