### PR TITLE
Use body instead of formatted_body for preview in matrix plugin

### DIFF
--- a/lib/plugins/matrix.py
+++ b/lib/plugins/matrix.py
@@ -68,7 +68,7 @@ class matrix_client:
         await self.client.close()
         return (
             formatted_content,
-            preview + "\n" + message_content["formatted_body"],
+            preview + "\n" + content,
             warnings,
         )
 


### PR DESCRIPTION
Currently, when comment the preview from Matrix, the formatted text appears incorrectly.
This pull request addresses this issue by displaying the raw content instead of the HTML format, ensuring proper rendering.