### PR TITLE
Introduce manual post splitting

### DIFF
--- a/lib/plugins/bluesky.py
+++ b/lib/plugins/bluesky.py
@@ -158,7 +158,7 @@ class bluesky_client:
             )
         return embed_external
 
-    def content_in_chunks(content, max_chunk_length):
+    def content_in_chunks(self, content, max_chunk_length):
         paragraphs = content.split("\n\n\n")
         for p in paragraphs:
             for chunk in textwrap.wrap(p.strip("\n"), max_chunk_length, replace_whitespace=False):

--- a/lib/plugins/bluesky.py
+++ b/lib/plugins/bluesky.py
@@ -158,6 +158,12 @@ class bluesky_client:
             )
         return embed_external
 
+    def content_in_chunks(content, max_chunk_length):
+        paragraphs = content.split("\n\n\n")
+        for p in paragraphs:
+            for chunk in textwrap.wrap(p.strip("\n"), max_chunk_length, replace_whitespace=False):
+                yield chunk
+
     def wrap_text_with_index(self, content):
         if len(content) <= self.max_content_length:
             return [content]
@@ -165,8 +171,8 @@ class bluesky_client:
         placeholder_content = re.sub(
             r"https?://\S+", lambda m: "~" * len(m.group()), content
         )
-        wrapped_lines = textwrap.wrap(
-            placeholder_content, self.max_content_length - 8, replace_whitespace=False
+        wrapped_lines = list(
+            self.content_in_chunks(placeholder_content, self.max_content_length - 8)
         )
         final_lines = []
         url_index = 0

--- a/lib/plugins/markdown.py
+++ b/lib/plugins/markdown.py
@@ -11,6 +11,7 @@ class markdown_client:
         )
 
     def format_content(self, content, mentions, hashtags, images, **kwargs):
+        content = content.replace("\n" * 3, "\n" * 2)
         _images = "\n".join(
             [f'![{image.get("alt_text", "")}]({image["url"]})' for image in images]
         )

--- a/lib/plugins/mastodon.py
+++ b/lib/plugins/mastodon.py
@@ -14,7 +14,7 @@ class mastodon_client:
         )
         self.max_content_length = kwargs.get("max_content_length", 500)
 
-    def content_in_chunks(content, max_chunk_length):
+    def content_in_chunks(self, content, max_chunk_length):
         paragraphs = content.split("\n\n\n")
         for p in paragraphs:
             for chunk in textwrap.wrap(p.strip("\n"), max_chunk_length, replace_whitespace=False):

--- a/lib/plugins/mastodon.py
+++ b/lib/plugins/mastodon.py
@@ -14,21 +14,28 @@ class mastodon_client:
         )
         self.max_content_length = kwargs.get("max_content_length", 500)
 
+    def content_in_chunks(content, max_chunk_length):
+        paragraphs = content.split("\n\n\n")
+        for p in paragraphs:
+            for chunk in textwrap.wrap(p.strip("\n"), max_chunk_length, replace_whitespace=False):
+                yield chunk
+
     def wrap_text_with_index(self, content):
         if len(content) <= self.max_content_length:
             return [content]
+        # urls always count as 23 chars on mastodon
+        placeholder = "~" * 23
         urls = re.findall(r"https?://\S+", content)
         placeholder_content = re.sub(
-            r"https?://\S+", lambda m: "~" * len(m.group()), content
+            r"https?://\S+", placeholder, content
         )
-        wrapped_lines = textwrap.wrap(
-            placeholder_content, self.max_content_length - 8, replace_whitespace=False
+        wrapped_lines = list(
+            self.content_in_chunks(placeholder_content, self.max_content_length - 8)
         )
         final_lines = []
         url_index = 0
         for i, line in enumerate(wrapped_lines, 1):
-            while "~~~~~~~~~~" in line and url_index < len(urls):
-                placeholder = "~" * len(urls[url_index])
+            while placeholder in line and url_index < len(urls):
                 line = line.replace(placeholder, urls[url_index], 1)
                 url_index += 1
             final_lines.append(f"{line} ({i}/{len(wrapped_lines)})")

--- a/lib/plugins/matrix.py
+++ b/lib/plugins/matrix.py
@@ -120,8 +120,9 @@ class matrix_client:
         await self.client.close()
         return True, event_link
 
-    def format_content(self, *args, **kwargs):
-        result = self.runner.run(self.async_format_content(*args, **kwargs))
+    def format_content(self, content, *args, **kwargs):
+        content = content.replace("\n" * 3, "\n" * 2)
+        result = self.runner.run(self.async_format_content(content, *args, **kwargs))
         return result
 
     def create_post(self, content, **kwargs):

--- a/lib/plugins/slack.py
+++ b/lib/plugins/slack.py
@@ -11,6 +11,12 @@ class slack_client:
         self.channel_id = kwargs.get("channel_id")
         self.max_content_length = kwargs.get("max_content_length", 40000)
 
+    def content_in_chunks(content, max_chunk_length):
+        paragraphs = content.split("\n\n\n")
+        for p in paragraphs:
+            for chunk in textwrap.wrap(p.strip("\n"), max_chunk_length, replace_whitespace=False):
+                yield chunk
+
     def wrap_text_with_index(self, content):
         if len(content) <= self.max_content_length:
             return [content]
@@ -18,8 +24,8 @@ class slack_client:
         placeholder_content = re.sub(
             r"https?://\S+", lambda m: "~" * len(m.group()), content
         )
-        wrapped_lines = textwrap.wrap(
-            placeholder_content, self.max_content_length - 8, replace_whitespace=False
+        wrapped_lines = list(
+            self.content_in_chunks(placeholder_content, self.max_content_length - 8)
         )
         final_lines = []
         url_index = 0

--- a/lib/plugins/slack.py
+++ b/lib/plugins/slack.py
@@ -11,7 +11,7 @@ class slack_client:
         self.channel_id = kwargs.get("channel_id")
         self.max_content_length = kwargs.get("max_content_length", 40000)
 
-    def content_in_chunks(content, max_chunk_length):
+    def content_in_chunks(self, content, max_chunk_length):
         paragraphs = content.split("\n\n\n")
         for p in paragraphs:
             for chunk in textwrap.wrap(p.strip("\n"), max_chunk_length, replace_whitespace=False):


### PR DESCRIPTION
... and count links on mastodon as fixed 23 chars

With this users can specify manual splits into sub-posts by including triple newlines in the content for plugins that support it.