### PR TITLE
Skip previously posted media for previewing

### DIFF
--- a/lib/galaxy_social.py
+++ b/lib/galaxy_social.py
@@ -146,9 +146,9 @@ class galaxy_social:
                 raise Exception(f"Failed to format post for {file_path}.\n{e}")
 
         stats = processed_files[file_path] if file_path in processed_files else {}
+        skiped_media = [media for media in metadata["media"] if stats.get(media)]
         if self.preview:
             message = f"👋 Hello! I'm your friendly social media assistant. Below are the previews of this post:\n`{file_path}`"
-            skiped_media = [media for media in metadata["media"] if stats.get(media)]
             if skiped_media:
                 message += f"\n\nSkipping post to {', '.join(skiped_media)}. because it was already posted."
             for media in set(metadata["media"]) - set(skiped_media):
@@ -160,10 +160,7 @@ class galaxy_social:
             return processed_files, message.strip()
 
         url = {}
-        for media in metadata["media"]:
-            if stats.get(media):
-                print("Skipping previous post to", media)
-                continue
+        for media in set(metadata["media"]) - set(skiped_media):
             formatted_content, _, _ = formatting_results[media]
             stats[media], url[media] = self.plugins[media].create_post(
                 formatted_content, file_path=file_path

--- a/lib/galaxy_social.py
+++ b/lib/galaxy_social.py
@@ -148,10 +148,10 @@ class galaxy_social:
         stats = processed_files[file_path] if file_path in processed_files else {}
         if self.preview:
             message = f"👋 Hello! I'm your friendly social media assistant. Below are the previews of this post:\n`{file_path}`"
-            for media in metadata["media"]:
-                if stats.get(media):
-                    print("Skipping previous post to", media)
-                    continue
+            skiped_media = [media for media in metadata["media"] if stats.get(media)]
+            if skiped_media:
+                message += f"\n\nSkipping post to {', '.join(skiped_media)}. because it was already posted."
+            for media in set(metadata["media"]) - set(skiped_media):
                 formatted_content, preview, warning = formatting_results[media]
                 message += f"\n\n## {media}\n\n"
                 message += preview

--- a/lib/galaxy_social.py
+++ b/lib/galaxy_social.py
@@ -144,9 +144,14 @@ class galaxy_social:
                 )
             except Exception as e:
                 raise Exception(f"Failed to format post for {file_path}.\n{e}")
+
+        stats = processed_files[file_path] if file_path in processed_files else {}
         if self.preview:
             message = f"👋 Hello! I'm your friendly social media assistant. Below are the previews of this post:\n`{file_path}`"
             for media in metadata["media"]:
+                if stats.get(media):
+                    print("Skipping previous post to", media)
+                    continue
                 formatted_content, preview, warning = formatting_results[media]
                 message += f"\n\n## {media}\n\n"
                 message += preview
@@ -155,7 +160,6 @@ class galaxy_social:
             return processed_files, message.strip()
 
         url = {}
-        stats = processed_files[file_path] if file_path in processed_files else {}
         for media in metadata["media"]:
             if stats.get(media):
                 print("Skipping previous post to", media)


### PR DESCRIPTION
To ensure that the preview matches the final post, this PR will skip previewing previously posted content when showing the preview again. This only occurs when additional media is added to an existing post.