### PR TITLE
Revert "Use body instead of formatted_body for preview in matrix plugin"

### DIFF
--- a/lib/plugins/matrix.py
+++ b/lib/plugins/matrix.py
@@ -68,7 +68,7 @@ class matrix_client:
         await self.client.close()
         return (
             formatted_content,
-            preview + "\n" + content,
+            preview + "\n" + message_content["formatted_body"],
             warnings,
         )
 


### PR DESCRIPTION
Reverts usegalaxy-eu/galaxy-social#38.
As I discussed with @wm75, it is necessary to show the formatted_body because this is what is displayed in the matrix. However, it still doesn't highlight the links without the markdown format.