### PR TITLE
Escape special characters in LinkedIn post content

### DIFF
--- a/lib/plugins/linkedin.py
+++ b/lib/plugins/linkedin.py
@@ -85,6 +85,26 @@ class linkedin_client:
 
     def linkedin_post(self, content, images):
         try:
+            # This is needed to escape special characters in the content
+            # https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/little-text-format?view=li-lms-2024-08#text
+            for char in [
+                "|",
+                "{",
+                "}",
+                "@",
+                "[",
+                "]",
+                "(",
+                ")",
+                "<",
+                ">",
+                "#",
+                "\\" "*",
+                "_",
+                "~",
+            ]:
+                content = content.replace(char, f"\\{char}")
+
             data = {
                 "author": self.organization_urn,
                 "commentary": content,

--- a/lib/plugins/linkedin.py
+++ b/lib/plugins/linkedin.py
@@ -88,6 +88,7 @@ class linkedin_client:
             # This is needed to escape special characters in the content
             # https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/little-text-format?view=li-lms-2024-08#text
             for char in [
+                "\\",
                 "|",
                 "{",
                 "}",
@@ -99,7 +100,7 @@ class linkedin_client:
                 "<",
                 ">",
                 "#",
-                "\\" "*",
+                "*",
                 "_",
                 "~",
             ]:


### PR DESCRIPTION
This pull request fixes an issue where special characters in the content of LinkedIn posts were not being escaped properly.
https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/little-text-format?view=li-lms-2024-08#text