### PR TITLE
Improve GitHub Actions workflows security

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -25,13 +25,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set environment variables
         run: |
           if [[ "${{ github.event.number }}" ]]; then
             echo "PR_NUMBER=${{ github.event.number }}" >> $GITHUB_ENV
-          else
+          elif [[ "${{ github.event.inputs.pr_number }}" =~ ^[0-9]+$ ]]; then
             echo "PR_NUMBER=${{ github.event.inputs.pr_number }}" >> $GITHUB_ENV
+          else
+            echo "Invalid PR number!" >&2
+            exit 1
           fi
           echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
           echo "MASTODON_ACCESS_TOKEN=${{ secrets.MASTODON_ACCESS_TOKEN }}" >> $GITHUB_ENV

--- a/.github/workflows/publish_content.yml
+++ b/.github/workflows/publish_content.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set environment variables
         run: |


### PR DESCRIPTION
Disable credential persistence in the GitHub Actions workflows and add validation for PR number input to ensure it is a valid number.