### PR TITLE
Add User-Agent header to image requests

### DIFF
--- a/lib/plugins/bluesky.py
+++ b/lib/plugins/bluesky.py
@@ -15,7 +15,10 @@ from .base import strip_markdown_formatting
 def compress_image_to_limit(image_url):
     if not isinstance(image_url, str) or not image_url.startswith(("http", "https")):
         return None
-    response = requests.get(image_url)
+    headers = {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+    }
+    response = requests.get(image_url, headers=headers)
     if response.status_code != 200 and not response.headers.get(
         "Content-Type", ""
     ).startswith("image/"):
@@ -265,12 +268,13 @@ class bluesky_client:
                     if img_data
                     else None
                 )
-                embed_images.append(
-                    atproto.models.AppBskyEmbedImages.Image(
-                        alt=image["alt_text"] if "alt_text" in image else "",
-                        image=upload,
+                if upload:
+                    embed_images.append(
+                        atproto.models.AppBskyEmbedImages.Image(
+                            alt=image["alt_text"] if "alt_text" in image else "",
+                            image=upload,
+                        )
                     )
-                )
             embed = (
                 atproto.models.AppBskyEmbedImages.Main(images=embed_images)
                 if embed_images

--- a/lib/plugins/linkedin.py
+++ b/lib/plugins/linkedin.py
@@ -121,8 +121,6 @@ class linkedin_client:
             }
             if images:
                 data["content"] = self.linkedin_upload_images(images)
-                if not data["content"]:
-                    return None
             headers = self.headers
             headers["Content-Type"] = "application/json"
             response = requests.post(
@@ -149,7 +147,10 @@ class linkedin_client:
                 value = response.json().get("value")
                 upload_url = value["uploadUrl"]
                 filename = os.path.basename(image["url"])
-                with requests.get(image["url"], stream=True) as r:
+                headers = {
+                    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+                }
+                with requests.get(image["url"], stream=True, headers=headers) as r:
                     r.raise_for_status()
                     with open(filename, "wb") as f:
                         for chunk in r.iter_content(chunk_size=8192):

--- a/lib/plugins/mastodon.py
+++ b/lib/plugins/mastodon.py
@@ -82,7 +82,10 @@ class mastodon_client:
     def create_post(self, content, **kwargs):
         media_ids = []
         for image in content["images"]:
-            response = requests.get(image["url"])
+            headers = {
+                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+            }
+            response = requests.get(image["url"], headers=headers)
             if response.status_code == 200 and response.headers.get(
                 "Content-Type", ""
             ).startswith("image/"):

--- a/lib/plugins/matrix.py
+++ b/lib/plugins/matrix.py
@@ -75,7 +75,10 @@ class matrix_client:
         posts = []
         for msg in content:
             if msg["msgtype"] == "m.image":
-                response = requests.get(msg["url"])
+                headers = {
+                    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+                }
+                response = requests.get(msg["url"], headers=headers)
                 if response.status_code != 200:
                     continue
                 temp = tempfile.NamedTemporaryFile()

--- a/lib/plugins/slack.py
+++ b/lib/plugins/slack.py
@@ -59,8 +59,10 @@ class slack_client:
         uploaded_files = []
         for image in images:
             filename = image["url"].split("/")[-1]
-
-            with requests.get(image["url"]) as response:
+            headers = {
+                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+            }
+            with requests.get(image["url"], headers=headers) as response:
                 if response.status_code != 200 or not response.headers.get(
                     "Content-Type", ""
                 ).startswith("image/"):


### PR DESCRIPTION
Include a User-Agent header in all image requests to ensure proper handling by servers.
This will prevent forbiden error on images from some websites like wikipedia.