### PR TITLE
Add GitHub Actions workflow for secret update reminders

### DIFF
--- a/.github/scripts/check_and_alert_secret.py
+++ b/.github/scripts/check_and_alert_secret.py
@@ -13,7 +13,7 @@ def main():
     repo = g.get_repo(repo_name)
     for secret in repo.get_secrets():
         secret_name = secret.name
-        if "linkedin" in secret_name:
+        if "linkedin" in secret_name.lower():
             updated_at = secret.updated_at
             today = datetime.now(timezone.utc)
             days_since = (today - updated_at).days

--- a/.github/scripts/check_and_alert_secret.py
+++ b/.github/scripts/check_and_alert_secret.py
@@ -1,0 +1,37 @@
+import os
+from datetime import datetime, timezone
+
+from github import Github
+
+
+def main():
+    threshold_days = 50
+    token = os.getenv("GH_TOKEN")
+    repo_name = os.getenv("GITHUB_REPOSITORY")
+
+    g = Github(token)
+    repo = g.get_repo(repo_name)
+    for secret in repo.get_secrets():
+        secret_name = secret.name
+        if "linkedin" in secret_name:
+            updated_at = secret.updated_at
+            today = datetime.now(timezone.utc)
+            days_since = (today - updated_at).days
+            print(
+                f"Secret '{secret_name}' last updated at: {updated_at} ({days_since} days ago)"
+            )
+
+            if days_since >= threshold_days:
+                issue_title = "Secret Update Reminder"
+                issue_body = (
+                    f"The secret **{secret_name}** was last updated **{days_since}** days ago.\n\n"
+                    "Please update this secret as soon as possible."
+                )
+                issue = repo.create_issue(title=issue_title, body=issue_body)
+                print(f"Issue created: {issue.html_url}")
+            else:
+                print("Secret is up-to-date; no alert needed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/secret-reminder.yml
+++ b/.github/workflows/secret-reminder.yml
@@ -1,0 +1,34 @@
+name: Secret Update Reminder using GitHub App Token
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  check_secret:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install PyGithub
+
+      - name: Create GitHub App Token
+        id: create_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Run secret check and alert script
+        run: python .github/scripts/check_and_alert_secret.py
+        env:
+          GH_TOKEN: ${{ steps.create_token.outputs.token }}

--- a/.github/workflows/secret-reminder.yml
+++ b/.github/workflows/secret-reminder.yml
@@ -3,6 +3,7 @@ name: Secret Update Reminder using GitHub App Token
 on:
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch:
 
 jobs:
   check_secret:


### PR DESCRIPTION
This pull request introduces a new feature to check and alert on outdated LinkedIn secrets in the repository using a GitHub App token (which needs to be configured before this PR get merged).
Demo: https://github.com/arash77/galaxy-social-main/issues/98