### PR TITLE
Add support for organization mentions in LinkedIn

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,4 +163,4 @@ Remember to add the env variable that needed for each social media seperatly.
 - Mastodon: Mentions should be in the format `username@server-domain`.
 - Matrix: Hashtags can be included in the post but have no special function. Mentions should be in the format `username:server-domain`.
 - Slack: Mentions and hashtags are not supported!
-- Linkedin: Mentions are not supported!
+- Linkedin: Mentions are only supported for organizations. The vanity name (company URL ID) should be used for this purpose.

--- a/docs/index.html
+++ b/docs/index.html
@@ -491,7 +491,7 @@
 
             const tagContainer = document.createElement("div");
             tagContainer.className = "space-y-2 hidden";
-            if (!name.includes("slack") && !name.includes("linkedin")) {
+            if (!name.includes("slack")) {
               const mIn = document.createElement("input");
               mIn.id = `mention-${name}`;
               mIn.placeholder = "Mentions";
@@ -506,14 +506,16 @@
               let validator = null;
 
               if (name.includes("bluesky")) {
-                format = "username.server";
+                format = "username.server (e.g. galaxyproject.bsky.social)";
                 validator = (tag) => /^[^@:\s]+\.[^@:\s]+$/.test(tag.value);
               } else if (name.includes("mastodon")) {
-                format = "username@server";
+                format = "username@server (e.g. galaxyproject@mstdn.science)";
                 validator = (tag) => /^[^@:\s]+@[^@:\s]+$/.test(tag.value);
               } else if (name.includes("matrix")) {
-                format = "username:server";
+                format = "username:server (e.g. bgruening:matrix.org)";
                 validator = (tag) => /^[^@:\s]+:[^@:\s]+$/.test(tag.value);
+                } else if (name.includes("linkedin")) {
+                  format = "vanityName (e.g. galaxy-project)";
               }
 
               if (format) {

--- a/lib/plugins/linkedin.py
+++ b/lib/plugins/linkedin.py
@@ -80,10 +80,22 @@ class linkedin_client:
             warnings = ""
 
         # convert markdown formatting because linkedin doesn't support it
+        protected_mentions = {}
+
+        def protect(match):
+            key = f"PROTECTED_MENTION_{len(protected_mentions)}"
+            protected_mentions[key] = match.group(0)
+            return key
+
+        content = re.sub(r"@\[[^\]]+\]\(urn:li:organization:\d+\)", protect, content)
+
         paragraphs = content.split("\n\n\n")
         for i, p in enumerate(paragraphs):
             paragraphs[i] = strip_markdown_formatting(p)
         content = "\n\n\n".join(paragraphs)
+
+        for key, value in protected_mentions.items():
+            content = content.replace(key, value)
 
         content += "\n"
         if mentions:

--- a/lib/plugins/linkedin.py
+++ b/lib/plugins/linkedin.py
@@ -49,9 +49,29 @@ class linkedin_client:
             final_lines.append(f"{line} ({i}/{len(wrapped_lines)})")
         return final_lines
 
+    def build_organization_mentions(self, mentions):
+        output = []
+        for mention in mentions:
+            vanity_name = mention.strip()
+            urn = None
+            try:
+                response = requests.get(
+                    f"{self.api_base_url}/organizations",
+                    headers=self.headers,
+                    params={"q": "vanityName", "vanityName": vanity_name},
+                )
+                response.raise_for_status()
+                elements = response.json().get("elements", [])
+                if elements and (org_id := elements[0].get("id")):
+                    urn = f"urn:li:organization:{org_id}"
+                    mention = elements[0].get("localizedName")
+            except Exception as e:
+                print(f"[WARN] Failed to resolve @{mention}: {e}")
+            output.append(f"@[{mention}]({urn})" if urn else f"@{mention}")
+        return " ".join(output)
+
     def format_content(self, content, mentions, hashtags, images, **kwargs):
-        # the mentions are not linked to anyone!
-        mentions = " ".join([f"@{v}" for v in mentions])
+        mentions = self.build_organization_mentions(mentions)
         hashtags = " ".join([f"#{v}" for v in hashtags])
         if len(images) > 20:
             warnings = f"A maximum of 20 images, not {len(images)}, can be included in a single linkedin post."


### PR DESCRIPTION
Implement functionality to link organization mentions in LinkedIn posts using vanity names.
vanity name is the company URL ID for example `galaxy-project` (www.linkedin.com/company/galaxy-project) or `erga-european-reference-genome-atlas` (www.linkedin.com/company/erga-european-reference-genome-atlas)

Base on LinkedIn API for [finding an organization](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/organizations/organization-lookup-api?view=li-lms-2024-06&tabs=http#find-an-organization----linkedin) and [mention an organization](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/posts-api?view=li-lms-2024-06&tabs=http#mention-an-organization)