### PR TITLE
Update LinkedIn API version to 202506

### DIFF
--- a/lib/plugins/linkedin.py
+++ b/lib/plugins/linkedin.py
@@ -17,7 +17,7 @@ class linkedin_client:
         self.headers = {
             "Authorization": f"Bearer {self.access_token}",
             "X-Restli-Protocol-Version": "2.0.0",
-            "LinkedIn-Version": "202406",
+            "LinkedIn-Version": "202506",
         }
         self.max_content_length = kwargs.get("max_content_length", 3000)
 


### PR DESCRIPTION
Upgrade the LinkedIn API version in the headers to ensure compatibility with the latest features and improvements, as the old version has been sunset today.