### PR TITLE
Fix Bluesky facets for URLs, hashtags, and mentions at the start of split posts

### DIFF
--- a/lib/plugins/bluesky.py
+++ b/lib/plugins/bluesky.py
@@ -253,7 +253,7 @@ class bluesky_client:
         }
         preview = formatted_content["body"]
         images_preview = "\n".join(
-            [f'![{image.get("alt_text", "")}]({image["url"]})' for image in images]
+            [f"![{image.get('alt_text', '')}]({image['url']})" for image in images]
         )
         preview += "\n\n" + images_preview
         return formatted_content, preview, warnings


### PR DESCRIPTION
When posts are split into multiple chunks, URLs, hashtags, or mentions at the beginning of continuation posts weren't being detected and linked. 
https://bsky.app/profile/galaxyproject.bsky.social/post/3m3a62zgow42h
https://bsky.app/profile/galaxyproject.bsky.social/post/3m3cfd53wzh2u
https://bsky.app/profile/galaxyproject.bsky.social/post/3m35qhvlm6l27