### PR TITLE
Harden GitHub Actions workflows with zizmor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 30

--- a/.github/workflows/galaxy_social.yml
+++ b/.github/workflows/galaxy_social.yml
@@ -13,6 +13,8 @@ on:
         description: "The number of the pull request to create preview for"
         required: true
 
+permissions: {}
+
 jobs:
   manage_content:
     name: Manage Content

--- a/.github/workflows/validate_social_plugin.yml
+++ b/.github/workflows/validate_social_plugin.yml
@@ -9,12 +9,18 @@ on:
       - ".github/workflows/galaxy_social.yml"
       - "README.md"
 
+permissions: {}
+
 jobs:
   validate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,31 @@
+name: GitHub Actions Security Analysis with zizmor
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/*'
+  pull_request:
+    paths:
+      - '.github/workflows/*'
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          advanced-security: false

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,9 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        '*': ref-pin
+  dangerous-triggers:
+    ignore:
+      - galaxy_social.yml
+      - validate_social_plugin.yml


### PR DESCRIPTION
Apply zizmor security best practices to all workflows.

See https://docs.zizmor.sh/

- Add top-level permissions: {} to restrict default GITHUB_TOKEN scope
- Add persist-credentials: false to checkout steps
- Run zizmor-action on changes to GitHub workflows
- Monthly dependabot for GitHub Actions updates