### PR TITLE
Fix LinkedIn 426 Upgrade Required: bump API version 202506 → 202607

### DIFF
--- a/lib/plugins/linkedin.py
+++ b/lib/plugins/linkedin.py
@@ -18,7 +18,7 @@ class linkedin_client:
         self.headers = {
             "Authorization": f"Bearer {self.access_token}",
             "X-Restli-Protocol-Version": "2.0.0",
-            "LinkedIn-Version": "202506",
+            "LinkedIn-Version": "202607",
         }
         self.max_content_length = kwargs.get("max_content_length", 3000)
 


### PR DESCRIPTION
## Problem

LinkedIn posts started failing in CI with `HTTP 426 Upgrade Required` on every call:

```
Linkedin error: 426 Client Error: Upgrade Required for url: https://api.linkedin.com/rest/images?action=initializeUpload
Linkedin error: 426 Client Error: Upgrade Required for url: https://api.linkedin.com/rest/posts
```

## Root cause

The `LinkedIn-Version` header was pinned to `202506`. LinkedIn Marketing API versions are [supported for a minimum of 12 months then sunset](https://learn.microsoft.com/en-us/linkedin/marketing/versioning); version `202506` was [sunset on Jun 15, 2026](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/recent-changes). Once a version is sunset, requests carrying that header return `426 Upgrade Required` (`NONEXISTENT_VERSION`) — LinkedIn does not fall back to the latest version automatically.

## Fix

Bump the `LinkedIn-Version` header from `202506` to `202607` — the [current latest version](https://learn.microsoft.com/en-us/linkedin/marketing/versioning), supported until ~July 2027.

```diff
 "X-Restli-Protocol-Version": "2.0.0",
-"LinkedIn-Version": "202506",
+"LinkedIn-Version": "202607",
```

This is the [documented migration procedure](https://learn.microsoft.com/en-us/linkedin/marketing/versioning#how-do-i-migrate-from-an-older-api-version-to-a-later-version) — update the `YYYYMM` header value to a supported version. No other endpoint or payload changes are needed: the Posts, Images, and Social Actions surfaces this integration uses (`/rest/posts`, `/rest/images?action=initializeUpload`, `/rest/socialActions/.../comments`, `DELETE /rest/posts/{id}`, `/rest/organizations?q=vanityName`) are unchanged in `202607`.

## Follow-up (not in this PR)

This will recur in ~12 months when `202607` sunsets. A longer-term fix is a scheduled workflow that watches the [LinkedIn changelog](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/recent-changes) (source: `MicrosoftDocs/linkedin-api-docs`) and opens a version-bump PR with the relevant changelog before the pinned version expires. Tracked separately.